### PR TITLE
Improved support for multiple servers with distributed cache

### DIFF
--- a/Modules/xSharePoint/DSCResources/MSFT_xSPDistributedCacheService/MSFT_xSPDistributedCacheService.schema.mof
+++ b/Modules/xSharePoint/DSCResources/MSFT_xSPDistributedCacheService/MSFT_xSPDistributedCacheService.schema.mof
@@ -32,7 +32,7 @@ class MSFT_xSPDistributedCacheService : OMI_BaseResource
     [Required, ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [Required] UInt32 CacheSizeInMB;
     [Required] String ServiceAccount;
-    [Write] String[] ServerProvisionOrder;
+    [Write] String ServerProvisionOrder[];
     [Write, EmbeddedInstance("MSFT_Credential")] String InstallAccount;
     [Required] Boolean CreateFirewallRules;
 };

--- a/Modules/xSharePoint/DSCResources/MSFT_xSPDistributedCacheService/MSFT_xSPDistributedCacheService.schema.mof
+++ b/Modules/xSharePoint/DSCResources/MSFT_xSPDistributedCacheService/MSFT_xSPDistributedCacheService.schema.mof
@@ -1,4 +1,4 @@
-/*
+﻿/*
 **Description**
 
 This resource is responsible for provisioning the distributed cache to the service it runs on. 
@@ -6,16 +6,23 @@ This is required in your farm on at least one server (as the behavior of [xSPCre
 The service will be provisioned or de-provisioned based on the Ensure property, and when provisioned the CacheSizeInMB property and ServiceAccount property will be used to configure it.
 The property createFirewallRules is used to determine if exceptions should be added to the windows firewall to allow communication between servers on the appropriate ports.
 
+The ServerProvisionOrder optional property is used when a pull server is handing out configurations to nodes in order to tell this resource about a specific order of enabling the caches.
+This allows for multiple servers to receive the same configuration, but they will always check for the server before them in the list first to ensure that it is running distributed cache.
+By doing this you can ensure that you do not create conflicts with two or more servers provisioning a cache at the same time.
+Note, this approach only makes a server check the others for distributed cache, it does not provision the cache automatically on all servers.
+If a previous server in the sequence does not appear to be running distributed cache after 30 minutes, the local server that was waiting will begin anyway.
+
 **Example**
 
     xSPDistributedCacheService EnableDistributedCache
     {
-        Name                = "AppFabricCachingService"
-        Ensure              = "Present"
-        CacheSizeInMB       = 8192
-        ServiceAccount      = "DEMO\ServiceAccount"
-        InstallAccount      = $InstallAccount
-        CreateFirewallRules = $true
+        Name                 = "AppFabricCachingService"
+        Ensure               = "Present"
+        CacheSizeInMB        = 8192
+        ServiceAccount       = "DEMO\ServiceAccount"
+        InstallAccount       = $InstallAccount
+        ServerProvisionOrder = @("server1", "server2")
+        CreateFirewallRules  = $true
     }
 */
 [ClassVersion("1.0.0.0"), FriendlyName("xSPDistributedCacheService")]
@@ -25,6 +32,7 @@ class MSFT_xSPDistributedCacheService : OMI_BaseResource
     [Required, ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [Required] UInt32 CacheSizeInMB;
     [Required] String ServiceAccount;
+    [Write] String[] ServerProvisionOrder;
     [Write, EmbeddedInstance("MSFT_Credential")] String InstallAccount;
     [Required] Boolean CreateFirewallRules;
 };

--- a/README.md
+++ b/README.md
@@ -94,11 +94,10 @@ Additional detailed documentation is included on the wiki on GitHub.
 
 ### Unreleased
 
- - xSPFarmSolution
-
  * Removed Visual Studio project files, added VSCode PowerShell extensions launch file
- * Added xSPDatabaseAAG resource
+ * Added xSPDatabaseAAG and xSPFarmSolution resources
  * Fixed bug with xSPWorkManagementServiceApp schema
+ * Added support for xSPDistributedCacheService to allow provisionin across multiple servers in a specific sequence
 
 ### 0.10.0.0
 


### PR DESCRIPTION
Adding a change to xSPDistributedCacheService to add an optional property "ServerProvisionOrder". What this does is makes sure that the cache is provisioned fully on previous servers before running locally. For example:

    xSPDistributedCacheService EnableDistributedCache
    {
        Name                 = "AppFabricCachingService"
        Ensure               = "Present"
        CacheSizeInMB        = 4096
        ServiceAccount       = $ServicePoolManagedAccount.UserName
        PsDscRunAsCredential = $SPSetupAccount
        CreateFirewallRules  = $true
        ServerProvisionOrder = @("Server1", "Server2", "Server3")
        DependsOn            = "[WaitForAll]WaitForServiceAppAccount"
    }

In this case server1 will run right away, server 2 will wait until it sees the cache running on server 1, and server 3 will wait to see it running on both servers 1 and 2