### PR TITLE
Bug fix for SPServer objects that use FQDNs

### DIFF
--- a/Modules/xSharePoint/DSCResources/MSFT_xSPDistributedCacheService/MSFT_xSPDistributedCacheService.psm1
+++ b/Modules/xSharePoint/DSCResources/MSFT_xSPDistributedCacheService/MSFT_xSPDistributedCacheService.psm1
@@ -172,7 +172,10 @@ function Set-TargetResource
                 $domain = (Get-CimInstance -ClassName Win32_ComputerSystem).Domain
                 $currentServer = "$currentServer.$domain"
                 $serviceInstance = Get-SPServiceInstance | Where-Object { ($_.Service.Tostring()) -eq "SPDistributedCacheService Name=AppFabricCachingService" -and ($_.Server.Name) -eq $currentServer }
-            }                        
+            }
+            if ($serviceInstance -eq $null) {
+                throw "Unable to locate a distributed cache service instance on $($env:computername) to remove"
+            }               
             $serviceInstance.Delete() 
             
             Remove-SPDistributedCacheServiceInstance

--- a/Modules/xSharePoint/DSCResources/MSFT_xSPDistributedCacheService/MSFT_xSPDistributedCacheService.psm1
+++ b/Modules/xSharePoint/DSCResources/MSFT_xSPDistributedCacheService/MSFT_xSPDistributedCacheService.psm1
@@ -103,6 +103,13 @@ function Set-TargetResource
                         $count = 0
                         $maxCount = 30
 
+                        # Attempt to see if we can find the service with just the computer name, or if we need to use the FQDN
+                        $si = Get-SPServiceInstance -Server $currentServer | Where-Object { $_.TypeName -eq "Distributed Cache" }                    
+                        if ($null -eq $si) { 
+                            $domain = (Get-CimInstance -ClassName Win32_ComputerSystem).Domain
+                            $currentServer = "$currentServer.$domain"
+                        }
+                        
                         Write-Verbose "Waiting for cache on $currentServer"
                         while (($count -lt $maxCount) -and ((Get-SPServiceInstance -Server $currentServer | ? { $_.TypeName -eq "Distributed Cache" -and $_.Status -eq "Online" }) -eq $null)) {
                             Start-Sleep -Seconds 60
@@ -161,6 +168,11 @@ function Set-TargetResource
         Write-Verbose -Message "Removing distributed cache to the server"
         Invoke-xSharePointCommand -Credential $InstallAccount -ScriptBlock {
             $serviceInstance = Get-SPServiceInstance | Where-Object { ($_.Service.Tostring()) -eq "SPDistributedCacheService Name=AppFabricCachingService" -and ($_.Server.Name) -eq $env:computername }
+            if ($null -eq $serviceInstance) { 
+                $domain = (Get-CimInstance -ClassName Win32_ComputerSystem).Domain
+                $currentServer = "$currentServer.$domain"
+                $serviceInstance = Get-SPServiceInstance | Where-Object { ($_.Service.Tostring()) -eq "SPDistributedCacheService Name=AppFabricCachingService" -and ($_.Server.Name) -eq $currentServer }
+            }                        
             $serviceInstance.Delete() 
             
             Remove-SPDistributedCacheServiceInstance

--- a/Modules/xSharePoint/DSCResources/MSFT_xSPSearchTopology/MSFT_xSPSearchTopology.psm1
+++ b/Modules/xSharePoint/DSCResources/MSFT_xSPSearchTopology/MSFT_xSPSearchTopology.psm1
@@ -83,7 +83,7 @@ function Set-TargetResource
         # Ensure the search service instance is running on all servers
         foreach($searchServer in $AllSearchServers) {
             
-            $searchService = Get-SPEnterpriseSearchServiceInstance -Identity $searchServer
+            $searchService = Get-SPEnterpriseSearchServiceInstance -Identity $searchServer -ErrorAction SilentlyContinue
             if ($searchService -eq $null) {
                 $domain = (Get-CimInstance -ClassName Win32_ComputerSystem).Domain
                 $searchServer = "$searchServer.$domain"
@@ -121,7 +121,7 @@ function Set-TargetResource
         # Get all service service instances to assign topology components to
         $AllSearchServiceInstances = @{}
         foreach ($server in $AllSearchServers) {
-            $serviceToAdd = Get-SPEnterpriseSearchServiceInstance -Identity $server
+            $serviceToAdd = Get-SPEnterpriseSearchServiceInstance -Identity $server -ErrorAction SilentlyContinue
             if ($searchService -eq $null) {
                 $domain = (Get-CimInstance -ClassName Win32_ComputerSystem).Domain
                 $server = "$server.$domain"

--- a/Modules/xSharePoint/DSCResources/MSFT_xSPSearchTopology/MSFT_xSPSearchTopology.psm1
+++ b/Modules/xSharePoint/DSCResources/MSFT_xSPSearchTopology/MSFT_xSPSearchTopology.psm1
@@ -121,7 +121,13 @@ function Set-TargetResource
         # Get all service service instances to assign topology components to
         $AllSearchServiceInstances = @{}
         foreach ($server in $AllSearchServers) {
-            $AllSearchServiceInstances.Add($server, (Get-SPEnterpriseSearchServiceInstance -Identity $server))
+            $serviceToAdd = Get-SPEnterpriseSearchServiceInstance -Identity $server
+            if ($searchService -eq $null) {
+                $domain = (Get-CimInstance -ClassName Win32_ComputerSystem).Domain
+                $server = "$server.$domain"
+                $serviceToAdd = Get-SPEnterpriseSearchServiceInstance -Identity $server    
+            }
+            $AllSearchServiceInstances.Add($server, $serviceToAdd)
         }
 
         # Get current topology and prepare a new one

--- a/Modules/xSharePoint/DSCResources/MSFT_xSPSearchTopology/MSFT_xSPSearchTopology.psm1
+++ b/Modules/xSharePoint/DSCResources/MSFT_xSPSearchTopology/MSFT_xSPSearchTopology.psm1
@@ -121,13 +121,14 @@ function Set-TargetResource
         # Get all service service instances to assign topology components to
         $AllSearchServiceInstances = @{}
         foreach ($server in $AllSearchServers) {
+            $serverName = $server
             $serviceToAdd = Get-SPEnterpriseSearchServiceInstance -Identity $server -ErrorAction SilentlyContinue
-            if ($searchService -eq $null) {
+            if ($serviceToAdd -eq $null) {
                 $domain = (Get-CimInstance -ClassName Win32_ComputerSystem).Domain
                 $server = "$server.$domain"
                 $serviceToAdd = Get-SPEnterpriseSearchServiceInstance -Identity $server    
             }
-            $AllSearchServiceInstances.Add($server, $serviceToAdd)
+            $AllSearchServiceInstances.Add($serverName, $serviceToAdd)
         }
 
         # Get current topology and prepare a new one

--- a/Modules/xSharePoint/DSCResources/MSFT_xSPUserProfileSyncService/MSFT_xSPUserProfileSyncService.psm1
+++ b/Modules/xSharePoint/DSCResources/MSFT_xSPUserProfileSyncService/MSFT_xSPUserProfileSyncService.psm1
@@ -104,7 +104,7 @@ function Set-TargetResource
                 throw [Exception] "No user profile service was found named $($params.UserProfileServiceAppName)"
             }
             $ups = $serviceApps | Where-Object { $_.TypeName -eq "User Profile Service Application" }
-            $ups.SetSynchronizationMachine($env:COMPUTERNAME, $syncService.ID, $params.FarmAccount.UserName, $params.FarmAccount.GetNetworkCredential().Password)
+            $ups.SetSynchronizationMachine($currentServer, $syncService.ID, $params.FarmAccount.UserName, $params.FarmAccount.GetNetworkCredential().Password)
 
             Start-SPServiceInstance -Identity $syncService.ID 
             

--- a/Modules/xSharePoint/DSCResources/MSFT_xSPUserProfileSyncService/MSFT_xSPUserProfileSyncService.psm1
+++ b/Modules/xSharePoint/DSCResources/MSFT_xSPUserProfileSyncService/MSFT_xSPUserProfileSyncService.psm1
@@ -96,7 +96,7 @@ function Set-TargetResource
             $currentServer = "$currentServer.$domain"
             $syncService = Get-SPServiceInstance -Server $currentServer | Where-Object { $_.TypeName -eq "User Profile Synchronization Service" }
         }
-        if ($serviceInstance -eq $null) {
+        if ($syncService -eq $null) {
             throw "Unable to locate a user profile service instance on $currentServer to start"
         }
         

--- a/Modules/xSharePoint/DSCResources/MSFT_xSPUserProfileSyncService/MSFT_xSPUserProfileSyncService.psm1
+++ b/Modules/xSharePoint/DSCResources/MSFT_xSPUserProfileSyncService/MSFT_xSPUserProfileSyncService.psm1
@@ -96,6 +96,9 @@ function Set-TargetResource
             $currentServer = "$currentServer.$domain"
             $syncService = Get-SPServiceInstance -Server $currentServer | Where-Object { $_.TypeName -eq "User Profile Synchronization Service" }
         }
+        if ($serviceInstance -eq $null) {
+            throw "Unable to locate a user profile service instance on $currentServer to start"
+        }
         
          # Start the Sync service if it should be running on this server
         if (($params.Ensure -eq "Present") -and ($syncService.Status -ne "Online")) {

--- a/Modules/xSharePoint/DSCResources/MSFT_xSPUserProfileSyncService/MSFT_xSPUserProfileSyncService.psm1
+++ b/Modules/xSharePoint/DSCResources/MSFT_xSPUserProfileSyncService/MSFT_xSPUserProfileSyncService.psm1
@@ -23,7 +23,7 @@ function Get-TargetResource
         $syncService = Get-SPServiceInstance -Server $env:COMPUTERNAME | Where-Object { $_.TypeName -eq "User Profile Synchronization Service" }
         if ($null -eq $syncService) { 
             $domain = (Get-CimInstance -ClassName Win32_ComputerSystem).Domain
-            $currentServer = "$currentServer.$domain"
+            $currentServer = "$($env:COMPUTERNAME).$domain"
             $syncService = Get-SPServiceInstance -Server $currentServer | Where-Object { $_.TypeName -eq "User Profile Synchronization Service" }
         }
 


### PR DESCRIPTION
We initially saw this bug about 10 months ago but couldn't reproduce so left it alone. It's finally reared its head again and I've been able to squash it. The scenario is that in some SharePoint installations you will see SPServer objects referred to using a FQDN (like "server.domain.name") instead of just the server name. This breaks xSPServiceInstance, xSPUserProfileSync, xSPSearchTopology and xSPDistributedCacheService as they all refer to these server objects in some form, so this PR covers a fix for each that sees us try to load a service instance from the computer name alone first, and if that returns null we re-run the check using the FQDN. 

Code review time @caadam @camiloborges @ykuijs @anlynes