### PR TITLE
Fixed case sensitive check of farm admins resource

### DIFF
--- a/Modules/xSharePoint/DSCResources/MSFT_xSPFarmAdministrators/MSFT_xSPFarmAdministrators.psm1
+++ b/Modules/xSharePoint/DSCResources/MSFT_xSPFarmAdministrators/MSFT_xSPFarmAdministrators.psm1
@@ -204,7 +204,7 @@ function Test-TargetResource
     if ($MembersToInclude) {
         Write-Verbose "Processing MembersToInclude parameter"
         ForEach ($member in $MembersToInclude) {
-            if (-not($CurrentValues.Members.Contains($member))) {
+            if (-not($CurrentValues.Members -contains $member)) {
                 Write-Verbose "$member is not a Farm Administrator. Set result to false"
                 $result = $false
             } else {
@@ -216,7 +216,7 @@ function Test-TargetResource
     if ($MembersToExclude) {
         Write-Verbose "Processing MembersToExclude parameter"
         ForEach ($member in $MembersToExclude) {
-            if ($CurrentValues.Members.Contains($member)) {
+            if ($CurrentValues.Members -contains $member) {
                 Write-Verbose "$member is a Farm Administrator. Set result to false"
                 $result = $false
             } else {

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Additional detailed documentation is included on the wiki on GitHub.
  * Fixed bug in managed account schedule get method
  * Fixed incorrect output of server name in xSPOutgoingEmailSettings 
  * Added xSPSearchContentSource resource
+ * Fixed bug in xSPFarmAdministrators where testing for users was case sensitive
 
 ### 0.12.0.0
 


### PR DESCRIPTION
@ykuijs Can I get you to review this one dude since it was your resource to begin with? The issue is that I was seeing SharePoint return "domain\user" where as my config had "Domain\User" (casing was the only difference) and it would fail a test, despite the user being in the group already. Just switched the Contains() method out for the PowerShell contains operator which isn't case sensitive.