### PR TITLE
Fixed bug with default URLs being changed in xSPAlternateUrl

### DIFF
--- a/Modules/xSharePoint/DSCResources/MSFT_xSPAlternateUrl/MSFT_xSPAlternateUrl.psm1
+++ b/Modules/xSharePoint/DSCResources/MSFT_xSPAlternateUrl/MSFT_xSPAlternateUrl.psm1
@@ -17,9 +17,18 @@ function Get-TargetResource
     $result = Invoke-xSharePointCommand -Credential $InstallAccount -Arguments $PSBoundParameters -ScriptBlock {
         $params = $args[0]
 
-        $aam = Get-SPAlternateURL -WebApplication $params.WebAppUrl -Zone $params.Zone | Select -First 1
+        $aam = Get-SPAlternateURL -WebApplication $params.WebAppUrl -Zone $params.Zone -ErrorAction SilentlyContinue | Select -First 1
         $url = $null
         $Ensure = "Absent"
+        
+        if (($aam -eq $null) -and ($params.Zone -eq "Default")) {
+            # The default zone URL will change the URL of the web app, so assuming it has been applied
+            # correctly then the first call there will fail as the WebAppUrl parameter will no longer
+            # be the URL of the web app. So the assumption is that if a matching default entry with
+            # the new public URL is found then it can be returned and will pass a test.
+            $aam = Get-SPAlternateURL -Zone $params.Zone | Where-Object { $_.PublicUrl -eq $params.Url } | Select -First 1
+        }
+        
         if ($aam -ne $null) {
             $url = $aam.PublicUrl
             $Ensure = "Present"

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Additional detailed documentation is included on the wiki on GitHub.
  * Added xSPSearchContentSource resource
  * Fixed a bug in xSPInstallPrereqs that would cause an updated version of AD rights management to fail the test method for SharePoint 2013
  * Fixed bug in xSPFarmAdministrators where testing for users was case sensitive
+ * Fixed a bug in xSPAlternateUrl to account for a default zone URL being changed
 
 ### 0.12.0.0
 

--- a/Tests/xSharePoint/xSharePoint.xSPAlternateUrl.Tests.ps1
+++ b/Tests/xSharePoint/xSharePoint.xSPAlternateUrl.Tests.ps1
@@ -121,6 +121,27 @@ Describe "xSPAlternateUrl" {
                 Assert-MockCalled Remove-SPAlternateURL
             }
         }
+        
+        Context "The default zone URL for a web app was changed using this resource" {
+            
+            Mock Get-SPAlternateUrl {
+                return @()
+            } -ParameterFilter { $WebApplication -eq $testParams.WebAppUrl }
+            Mock Get-SPAlternateUrl {
+                return @(
+                    @{
+                        IncomingUrl = $testParams.Url
+                        Zone = $testParams.Zone
+                        PublicUrl = $testParams.Url
+                    }
+                )
+            } -ParameterFilter { $WebApplication -eq $null }
+            $testParams.Ensure = "Present"
+            
+            it "should still return true in the test method despite the web app URL being different" {
+                Test-TargetResource @testParams | Should Be $true
+            }
+        }
     }
 }
 


### PR DESCRIPTION
@caadam @camiloborges @anlynes @ykuijs Code review time - This is a quick one to account for the AAMs being changed in the default zone.