### PR TITLE
Added basic CT Hub URL parameter

### DIFF
--- a/Modules/xSharePoint/DSCResources/MSFT_xSPManagedMetadataServiceApp/MSFT_xSPManagedMetaDataServiceApp.psm1
+++ b/Modules/xSharePoint/DSCResources/MSFT_xSPManagedMetadataServiceApp/MSFT_xSPManagedMetaDataServiceApp.psm1
@@ -8,6 +8,7 @@ function Get-TargetResource
         [parameter(Mandatory = $true)]  [System.String] $ApplicationPool,
         [parameter(Mandatory = $false)] [System.String] $DatabaseServer,
         [parameter(Mandatory = $false)] [System.String] $DatabaseName,
+        [parameter(Mandatory = $false)] [System.String] $ContentTypeHubUrl,
         [parameter(Mandatory = $false)] [System.Management.Automation.PSCredential] $InstallAccount      
     )
 
@@ -50,6 +51,7 @@ function Set-TargetResource
         [parameter(Mandatory = $true)]  [System.String] $ApplicationPool,
         [parameter(Mandatory = $false)] [System.String] $DatabaseServer,
         [parameter(Mandatory = $false)] [System.String] $DatabaseName,
+        [parameter(Mandatory = $false)] [System.String] $ContentTypeHubUrl,
         [parameter(Mandatory = $false)] [System.Management.Automation.PSCredential] $InstallAccount      
     )
 
@@ -62,6 +64,10 @@ function Set-TargetResource
             
 
             if ($params.ContainsKey("InstallAccount")) { $params.Remove("InstallAccount") | Out-Null }
+            if ($params.ContainsKey("ContentTypeHubUrl")) {
+                $params.Add("HubUri", $params.ContentTypeHubUrl)
+                $params.Remove("ContentTypeHubUrl")
+            }
 
             $app = New-SPMetadataServiceApplication @params 
             if ($null -ne $app)
@@ -101,6 +107,7 @@ function Test-TargetResource
         [parameter(Mandatory = $true)]  [System.String] $ApplicationPool,
         [parameter(Mandatory = $false)] [System.String] $DatabaseServer,
         [parameter(Mandatory = $false)] [System.String] $DatabaseName,
+        [parameter(Mandatory = $false)] [System.String] $ContentTypeHubUrl,
         [parameter(Mandatory = $false)] [System.Management.Automation.PSCredential] $InstallAccount      
     )
 

--- a/Modules/xSharePoint/DSCResources/MSFT_xSPManagedMetadataServiceApp/MSFT_xSPManagedMetaDataServiceApp.schema.mof
+++ b/Modules/xSharePoint/DSCResources/MSFT_xSPManagedMetadataServiceApp/MSFT_xSPManagedMetaDataServiceApp.schema.mof
@@ -23,5 +23,6 @@ class MSFT_xSPManagedMetaDataServiceApp : OMI_BaseResource
     [Required, Description("The application pool that the service app will use")] string ApplicationPool;
     [Write, Description("The name of the database server which will host the application")] string DatabaseServer;
     [Write, Description("The name of the database for the service application")] string DatabaseName;
+    [Write, Description("The URL of the content type hub for this app (only set when the app is provisioned)")] string ContentTypeHubUrl;
     [Write, Description("POWERSHELL 4 ONLY: The account to run this resource as, use PsDscRunAsAccount if using PowerShell 5"), EmbeddedInstance("MSFT_Credential")] String InstallAccount;
 };

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Additional detailed documentation is included on the wiki on GitHub.
  * Added xSPSearchContentSource resource
  * Fixed a bug in xSPInstallPrereqs that would cause an updated version of AD rights management to fail the test method for SharePoint 2013
  * Fixed bug in xSPFarmAdministrators where testing for users was case sensitive
+ * Added content type hub URL option to xSPManagedMetadataServiceApp for when it provisions a service app
 
 ### 0.12.0.0
 


### PR DESCRIPTION
@ykuijs @caadam @camiloborges @anlynes - Code review. Quick one here, just added an option to provision MMS with a content type hub URL. I'll add a work item tagged as technical debt to track the fact that we don't monitor this URL and update it once the MMS is provisioned (found an easy way to set it, but no easy way to retrieve the current value) so we can revisit this later, but I wanted to get the basic property in so we didn't need to make a schema change later to add the property.