### PR TITLE
Fixed bug with schedule type not being tested as a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log for SharePoint DSC
 
+### Unreleased
+
+ * Fixed a bug with SPTimerJobState that prevented a custom schedule being applied to a timer job
+
 ### 1.0
 
  * Renamed module from xSharePoint to SharePointDSC

--- a/Modules/SharePointDSC/DSCResources/MSFT_SPTimerJobState/MSFT_SPTimerJobState.psm1
+++ b/Modules/SharePointDSC/DSCResources/MSFT_SPTimerJobState/MSFT_SPTimerJobState.psm1
@@ -33,12 +33,17 @@ function Get-TargetResource
         # Check if timer job if found
         if ($timerjob -eq $null) { return $null }
         
+        $schedule = $null
+        if ($null -ne $timerjob.Schedule) {
+            $schedule = $timerjob.Schedule.ToString()
+        }
+        
         if ($timerjob.WebApplication -eq $null) {
             # Timer job is not associated to web application
             return @{
                 Name = $params.Name
                 Enabled = -not $timerjob.IsDisabled
-                Schedule = $timerjob.Schedule
+                Schedule = $schedule
                 InstallAccount = $params.InstallAccount
             }
         } else {
@@ -47,7 +52,7 @@ function Get-TargetResource
                 Name = $params.Name
                 WebApplication = $timerjob.WebApplication.Url
                 Enabled = -not $timerjob.IsDisabled
-                Schedule = $timerjob.Schedule
+                Schedule = $schedule
                 InstallAccount = $params.InstallAccount
             }
         }


### PR DESCRIPTION
Quick one to fix a bug I found in SPTimerJobState - looks like the object coming back from schedule is a custom object, not a string (it's ToString() method hides that though so it looks like a string until you interrogate it). A quick ToString() on it in the get method stops the tests from throwing a false result when it is actually set correctly.

@ykuijs You wanna code review this one seeing as that module was yours to begin with? Thanks dude

- [X] Change details added to Unreleased section of readme.md?
- [X] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [X] Examples updated for both the single server and small farm templates in the examples folder?
- [X] New/changed code adheres to [Style Guidelines]?(https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsharepoint/303)
<!-- Reviewable:end -->
