### PR TITLE
Fix to group permissions in SPServiceAppSecurity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
  * Fixed a bug with SPTimerJobState that prevented a custom schedule being applied to a timer job
+ * Fixed a bug with the detection of group principals vs. user principals in SPServiceAppSecurity
 
 ### 1.0
 

--- a/Modules/SharePointDSC/Modules/SharePointDSC.Util/SharePointDSC.Util.psm1
+++ b/Modules/SharePointDSC/Modules/SharePointDSC.Util/SharePointDSC.Util.psm1
@@ -290,6 +290,32 @@ function Test-SPDSCUserIsLocalAdmin() {
         Where-Object { $_ -eq $accountName }
 }
 
+function Test-SPDSCIsADUser() {
+    [OutputType([System.Boolean])]
+    [CmdletBinding()]
+    param (
+        [string] $IdentityName
+    )
+
+    $searcher = New-Object System.DirectoryServices.DirectorySearcher
+    $searcher.filter = "((samAccountName=$IdentityName))"
+    $searcher.SearchScope = "subtree"
+    $searcher.PropertiesToLoad.Add("objectClass") | Out-Null
+    $searcher.PropertiesToLoad.Add("objectCategory") | Out-Null
+    $searcher.PropertiesToLoad.Add("name") | Out-Null
+    $result = $searcher.FindOne()
+
+    if ($null -eq $result) {
+        throw "Unable to locate identity '$IdentityName' in the current domain."
+    }
+
+    if ($result[0].Properties.objectclass -contains "user") {
+        return $true
+    } else {
+        return $false
+    }
+}
+
 function Set-SPDSCObjectPropertyIfValueExists() {
     [CmdletBinding()]
     param

--- a/Modules/SharePointDSC/Modules/SharePointDSC.Util/SharePointDSC.Util.psm1
+++ b/Modules/SharePointDSC/Modules/SharePointDSC.Util/SharePointDSC.Util.psm1
@@ -297,6 +297,10 @@ function Test-SPDSCIsADUser() {
         [string] $IdentityName
     )
 
+    if ($IdentityName -like "*\*") {
+        $IdentityName = $IdentityName.Substring($IdentityName.IndexOf('\') + 1)
+    }
+
     $searcher = New-Object System.DirectoryServices.DirectorySearcher
     $searcher.filter = "((samAccountName=$IdentityName))"
     $searcher.SearchScope = "subtree"

--- a/Modules/SharePointDSC/SharePointDSC.psd1
+++ b/Modules/SharePointDSC/SharePointDSC.psd1
@@ -79,6 +79,7 @@ CmdletsToExport = @("Invoke-SPDSCCommand",
                     "Test-SPDSCRunAsCredential",
                     "Test-SPDSCUserIsLocalAdmin",
                     "Test-SPDSCSpecificParameters",
+                    "Test-SPDSCIsADUser",
                     "Set-SPDSCObjectPropertyIfValueExists",
                     "Get-SPDSCUserProfileSubTypeManager")
 

--- a/Tests/SharePointDSC/SharePointDSC.SPServiceAppSecurity.Tests.ps1
+++ b/Tests/SharePointDSC/SharePointDSC.SPServiceAppSecurity.Tests.ps1
@@ -35,7 +35,9 @@ Describe "SPServiceAppSecurity - SharePoint Build $((Get-Item $SharePointCmdletM
         }
         Remove-Module -Name "Microsoft.SharePoint.PowerShell" -Force -ErrorAction SilentlyContinue
         Import-Module $Global:CurrentSharePointStubModule -WarningAction SilentlyContinue
-                
+        
+        Mock Test-SPDSCIsADUser { return $true }
+        
         Mock New-SPClaimsPrincipal { return @{ Value = "CONTOSO\user2" }}
         Mock Grant-SPObjectSecurity {}
         Mock Revoke-SPObjectSecurity {}


### PR DESCRIPTION
This is a fix to a minor issue where the wrong claim type is used when applying permissions to AD groups instead of users for service app sharing and admin permissions.

- [X] Change details added to Unreleased section of readme.md?
- [X] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [X] Examples updated for both the single server and small farm templates in the examples folder?
- [X] New/changed code adheres to [Style Guidelines]?(https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsharepoint/307)
<!-- Reviewable:end -->
